### PR TITLE
Change genomedata-load-data from binary to Python with c-extension

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -15,7 +15,7 @@ jobs:
     # Run job for both python versions in the docker image
     strategy:
       matrix:
-        python-version: [2, 3]
+        python-version: [3]
     container:
       image: hoffmanlab/genomedata-test:latest
       env:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -13,20 +13,15 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     # Run job for both python versions in the docker image
-    strategy:
-      matrix:
-        python-version: [3]
     container:
       image: hoffmanlab/genomedata-test:latest
-      env:
-        GENOMEDATA_TEST_PYTHON_VERSION: ${{matrix.python-version}}
 
     steps:
       - uses: actions/checkout@v2
       - name: Build repository
         run: |
-          python${GENOMEDATA_TEST_PYTHON_VERSION} -m pip install --verbose .
+          python3 -m pip install --verbose .
           pip list
       - name: Run tests
         run: |
-          cd test && python${GENOMEDATA_TEST_PYTHON_VERSION} run_tests.py
+          cd test && python3 run_tests.py

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,12 +17,12 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip build
         pip install setuptools twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist
+        python -m build
         twine upload dist/*

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,35 +1,22 @@
 FROM ubuntu:latest
 
-# Install Ubuntu 18.04.01 LTS (Bionic Beaver)
+# Install latest Ubuntu LTS 
+# Install HDF5 and development libraries
 # Install pkg-config for locationg development files (hdf5)
-# Install python 2.7 and pip
-# Install python 3.6 and pip3
-# Install HDF5
-# Install Mercurial for hgtools (needed to install for testing)
+# Install Python 3 and development libraries
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential \
     pkg-config \
-    python \
-    python2-dev \
     python3 \
     python3-dev \
     python3-pip \
     libhdf5-dev \
     hdf5-tools \
     git \
-    curl \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 
-# Install pip for Python 2
-RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && python2 get-pip.py
-
-# Update pip
 # Install PyFlakes for testing
-RUN python2 -m pip install --upgrade \ 
-    pip \
-    setuptools \
-    pyflakes
 RUN python3 -m pip install --upgrade \
     pip \
     setuptools \

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     build-essential \
     pkg-config \
     python \
+    python2-dev \
     python3 \
+    python3-dev \
     python3-pip \
     libhdf5-dev \
     hdf5-tools \
@@ -20,7 +22,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 && rm -rf /var/lib/apt/lists/*
 
 # Install pip for Python 2
-RUN curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py && python2 get-pip.py
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && python2 get-pip.py
 
 # Update pip
 # Install PyFlakes for testing

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+1.6.0:
+* drop support for Python 2
+* genomedata-load-data: changed to a python script with a c-extension
+
 1.5.0:
 * genomedata-load-data: fix bad error message when loading process fails
 * genomedata-load-seq: add chromosome name mapping based on assembly reports

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
 1.6.0:
-* drop support for Python 2
+* required Python is now >=3.7
 * genomedata-load-data: changed to a python script with a c-extension
 
 1.5.0:

--- a/genomedata/_load_data.py
+++ b/genomedata/_load_data.py
@@ -13,6 +13,7 @@ from argparse import ArgumentParser
 from subprocess import PIPE, Popen
 
 from . import __version__
+from ._load_data_c_ext import load_data_from_stdin
 from ._util import SUFFIX_GZ, die
 
 BIG_WIG_SIGNATURE = 0x888FFC26
@@ -141,31 +142,18 @@ def is_big_wig(filename):
 
 def parse_args(args):
 
-    description = ("Load data from DATAFILE into the specified TRACKNAME"
-                   " of the Genomedata archive")
+    description = ("Load data into genomedata format. "
+                   "Takes track data in on stdin")
 
     parser = ArgumentParser(description=description,
                             prog='genomedata-load-data')
     
-    parser.add_argument('--version', action='version', version=__version__)
+    parser.add_argument('-V', '--version', action='version', version=__version__)
 
     parser.add_argument('gdarchive', help='genomedata archive')
     parser.add_argument('trackname', help='track name')
-    parser.add_argument('datafile', help='data file')
 
-    parser.add_argument("-m", "--maskfile",
-                        help='A BED file containing regions to mask out from'
-                        'the data file')
-
-    parser.add_argument("-c", "--chunk-size",
-                        metavar="NROWS", type=int,
-                        default=DEFAULT_CHUNK_SIZE,
-                        help="Chunk hdf5 data into blocks of NROWS."
-                        " A higher value increases compression but slows"
-                        " random access. Must always be smaller than the"
-                        " max size for a dataset. [default: %(default)s]")
-
-    parser.add_argument("--verbose", default=False, action="store_true",
+    parser.add_argument("-v", "--verbose", default=False, action="store_true",
                       help="Print status and diagnostic messages")
 
     args = parser.parse_args(args)
@@ -175,8 +163,7 @@ def parse_args(args):
 
 def main(argv=sys.argv[1:]):
     args = parse_args(argv)
-    load_data(args.gdarchive, args.trackname, args.datafile,
-              args.maskfile, verbose=args.verbose, chunk_size=args.chunk_size)
+    load_data_from_stdin(args.gdarchive, args.trackname, args.verbose)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/genomedata/_load_data.py
+++ b/genomedata/_load_data.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 """
-_load_data.py: A python interface for genome_load_data.c
+_load_data.py: A python interface for both genomedata_load_data.c and load_genomedata.py
 """
 
 import struct
@@ -13,7 +13,7 @@ from argparse import ArgumentParser
 from subprocess import PIPE, Popen
 
 from . import __version__
-from ._load_data_c_ext import load_data_from_stdin
+from ._c_load_data import load_data_from_stdin
 from ._util import SUFFIX_GZ, die
 
 BIG_WIG_SIGNATURE = 0x888FFC26

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,15 @@ LDFLAGS_LIBRARY_SWITCH = "-l"
 LDFLAGS_LIBRARY_PATH_SWITCH = "-L"
 CFLAGS_INCLUDE_PATH_SWITCH = "-I"
 
-if (sys.version_info[0] == 2 and sys.version_info[1] < 7) or \
-   (sys.version_info[0] == 3 and sys.version_info[1] < 4):
-    print("Genomedata requires Python version 2.7 or 3.4 or later")
+MINIMUM_PYTHON_VERSION_MAJ = 3
+MINIMUM_PYTHON_VERSION_MIN = 7
+MINIMUM_PYTHON_VERSION_STR = "{}.{}".format(MINIMUM_PYTHON_VERSION_MAJ,
+                                            MINIMUM_PYTHON_VERSION_MIN)
+
+if (sys.version_info[0] == MINIMUM_PYTHON_VERSION_MAJ and 
+    sys.version_info[1] < MINIMUM_PYTHON_VERSION_MIN):
+    print("Genomedata requires Python version {} or "
+          "later".format(MINIMUM_PYTHON_VERSION_STR))
     sys.exit(1)
 
 doclines = __doc__.splitlines()
@@ -47,7 +53,6 @@ classifiers = ["Natural Language :: English",
                "(GPLv2)",
                "Topic :: Scientific/Engineering :: Bio-Informatics",
                "Operating System :: Unix",
-               "Programming Language :: Python :: 2.7",
                "Programming Language :: Python :: 3"]
 
 entry_points = """
@@ -163,5 +168,6 @@ if __name__ == "__main__":
           include_package_data=True,
           entry_points=entry_points,
           ext_package= "genomedata", # place extension in the base genomedata package
-          ext_modules=[load_data_module]
+          ext_modules=[load_data_module],
+          python_requires=">={}".format(MINIMUM_PYTHON_VERSION_STR)
           )

--- a/setup.py
+++ b/setup.py
@@ -136,13 +136,12 @@ else:
             library_dirnames.append(word.lstrip(LDFLAGS_LIBRARY_PATH_SWITCH))
 
 
-load_data_module = Extension('_load_data_c_ext', # needs to match C file PyInit definition
+load_data_module = Extension('_c_load_data', # needs to match C file PyInit definition
                             sources=source_files,
                             include_dirs = include_dirnames,
                             libraries = libs,
                             library_dirs = library_dirnames,
                             define_macros = c_define_macros,
-                            extra_compile_args = ["-UNDEBUG"] # NB: Keep assert macros functioning
                             )
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,24 +13,12 @@ from __future__ import absolute_import, division, print_function
 
 # Copyright 2008-2014 Michael M. Hoffman <michael.hoffman@utoronto.ca>
 
-import errno
 import os
-from shlex import split
 import sys
 import tokenize
 
-from distutils.command.clean import clean
-from distutils.command.build_scripts import build_scripts
-from distutils.spawn import find_executable
-from platform import system, processor
-from setuptools import find_packages, setup
-from shutil import rmtree
-from subprocess import CalledProcessError, check_call, check_output
-
-DEFAULT_SHELL_ENCODING = "ascii"
-LDFLAGS_LIBRARY_SWITCH = "-l"
-LDFLAGS_LIBRARY_PATH_SWITCH = "-L"
-CFLAGS_INCLUDE_PATH_SWITCH = "-I"
+from distutils import sysconfig
+from setuptools import Extension, find_packages, setup
 
 if (sys.version_info[0] == 2 and sys.version_info[1] < 7) or \
    (sys.version_info[0] == 3 and sys.version_info[1] < 4):
@@ -60,6 +48,7 @@ genomedata-info = genomedata._info:main
 genomedata-query = genomedata._query:main
 genomedata-histogram = genomedata._histogram:main
 genomedata-load = genomedata.load_genomedata:main
+genomedata-load-data = genomedata._load_data:main
 genomedata-load-seq = genomedata._load_seq:main
 genomedata-load-assembly = genomedata._load_seq:main
 genomedata-open-data = genomedata._open_data:main
@@ -77,89 +66,6 @@ setup_requires = ["setuptools_scm"] # source control management packaging
 install_requires = ["numpy", "tables>=3.0,!=3.4.1", "six",
                     "textinput>=0.2.0", "path.py>=11"]
 
-arch = "_".join([system(), processor()])
-
-include_gnulib = (system() != "Linux")
-GNULIB_BUILD_DIR = "src/build-deps"
-GNULIB_LIB_DIR = "%s/gllib" % GNULIB_BUILD_DIR
-
-
-class DirList(list):
-    """Maintain a unique list of valid directories.
-
-    This is a list, not a set to maintain order.
-
-    add_dir: add the given directory to the set
-    add_env: add the given ':'-separated environment variable to the set
-    """
-    def add_dir(self, dirname):
-        if dirname not in self and os.path.isdir(dirname):
-            self.append(dirname)
-
-    def add_env(self, env):
-        if env in os.environ:
-            for dirname in os.environ[env].split(":"):
-                self.add_dir(dirname)
-
-    def append(self, item):
-        if item not in self:
-            list.append(self, item)
-
-# Get compile flags/information from environment
-library_dirnames = DirList()
-include_dirnames = DirList()
-
-if "HDF5_DIR" in os.environ:
-    hdf5_dir = os.environ["HDF5_DIR"]
-    library_dirnames.add_dir(os.path.join(hdf5_dir, "lib"))
-    include_dirnames.add_dir(os.path.join(hdf5_dir, "include"))
-
-if include_gnulib:
-    # Gnulib for OS X dependencies
-    library_dirnames.add_dir(GNULIB_LIB_DIR)
-    include_dirnames.add_dir(GNULIB_LIB_DIR)
-
-library_dirnames.add_env("LIBRARY_PATH")
-library_dirnames.add_env("LD_LIBRARY_PATH")
-include_dirnames.add_env("C_INCLUDE_PATH")
-
-try:
-    shell_encoding = sys.stdout.encoding
-    # Depending on the shell, python version (2), and environment this is not
-    # guaranteed to be set. Attempt to fall back to a best-guess if it is not
-    # set
-    if not shell_encoding:
-        shell_encoding = DEFAULT_SHELL_ENCODING
-
-    pkg_config_cflags = split(check_output(
-                                ["pkg-config", "--cflags", "hdf5"]
-                             ).decode(shell_encoding))
-    pkg_config_libs = split(check_output(
-                                ["pkg-config", "--libs", "hdf5"]
-                           ).decode(shell_encoding))
-except OSError as err:
-    # OSError ENOENT occurs when pkg-config is not installed
-    if err.errno == errno.ENOENT:
-        pass
-    else:
-        raise err
-except CalledProcessError:
-    # CalledProcessError occurs when hdf5 is not found by pkg-config
-    pass
-else:
-    for path in pkg_config_cflags:
-        assert path.find(CFLAGS_INCLUDE_PATH_SWITCH) == 0
-        include_dirnames.add_dir(path.lstrip(CFLAGS_INCLUDE_PATH_SWITCH))
-    for word in pkg_config_libs:
-        if not word.startswith(LDFLAGS_LIBRARY_SWITCH):
-            assert word.startswith(LDFLAGS_LIBRARY_PATH_SWITCH)
-            library_dirnames.add_dir(word.lstrip(LDFLAGS_LIBRARY_PATH_SWITCH))
-
-## fix types, since distutils does type-sniffing:
-library_dirnames = list(library_dirnames)
-include_dirnames = list(include_dirnames)
-
-
 # Monkey patches tokenize.detect_encoding() to return a blank string when it can't recognize encoding
 # setuptools attempts to process some of the C files present, and errors because it can't determine encoding
 try:
@@ -174,154 +80,31 @@ else:
             return "", []
     tokenize.detect_encoding = detect_encoding
 
-class InstallationError(Exception):
-    pass
+source_files = ["src/genomedata_load_data.c"]
+# sz may be needed here if it's statically builtin with an hdf5 distribution? Or someone built their own hdf5 version with sz in which case they should rely on using LD_LIBRARY_PATH?
+libs = ["hdf5", "m", "z"] # hdf5, math, zlib, (sz? lossless compression libray for scientific data)
+library_dirnames = []
+include_dirnames = [
+    sysconfig.get_config_var("INCLUDEDIR"), # environment headers
+]
+c_define_macros = [("H5_NO_DEPRECATED_SYMBOLS", None)]
 
+if "HDF5_DIR" in os.environ:
+    hdf5_dir = os.environ["HDF5_DIR"]
+    include_dirnames.append(os.path.join(hdf5_dir, "include"))
+    library_dirnames.append(os.path.join(hdf5_dir, "lib"))
 
-class CleanWrapper(clean):
-    """Wraps `python setup.py clean` to also cleans Gnulib installation"""
-    def run(self):
-        clean.run(self)
-        if include_gnulib:
-            print(">> Cleaning Gnulib build directory", file=sys.stderr)
-            try:
-                check_call(["make", "clean"], cwd=GNULIB_BUILD_DIR)
-            except CalledProcessError:
-                print(">> WARNING: Failed to clean Gnulib build!", file=sys.stderr)
+load_data_module = Extension('_load_data_c_ext', # needs to match C file PyInit definition
+                            sources=source_files,
+                            include_dirs = include_dirnames,
+                            libraries = libs,
+                            library_dirs = library_dirnames,
+                            define_macros = c_define_macros,
+                            extra_compile_args = ["-UNDEBUG"] # NB: Keep assert macros functioning
+                            )
 
-
-class BuildScriptWrapper(build_scripts):
-    """Override the script-building machinery of distutils.
-
-    Intercepts attempts to build scripts with the `scripts` argument to setup()
-    If scripts is a list, this doesn't do anything
-    If instead, it is a dict: BIN_NAME -> [SOURCE_FILES], and at least one
-    of those source files is a .c file, then this script hops in.
-
-    It extends the distutils compiler to compile the [SOURCE_FILES]
-    and then links them into an executable called BIN_NAME, placing
-    this executable into the appropriate directory to get added to the
-    egg's bin directory.
-    """
-    def _get_compiler(self):
-        from distutils.ccompiler import new_compiler
-        from distutils.sysconfig import customize_compiler
-
-        compiler = new_compiler()
-        customize_compiler(compiler)
-
-        # Customize compiler options
-        compiler.add_library("hdf5")
-
-        # these two are necessary if a static HDF5 is installed:
-        compiler.add_library("m")
-        compiler.add_library("z")
-
-        # is a static HDF5 is installed with --with-szip?
-        h5dump_filename = find_executable("h5dump")
-        try:
-            # XXX: output should be redirected to /dev/null
-            check_call("objdump -t %s | fgrep szip" % h5dump_filename,
-                       shell=True)
-        except CalledProcessError:
-            pass
-        else:
-            compiler.add_library("sz")
-
-        if include_gnulib:
-            compiler.add_library("gnu")
-
-        # Remove DNDEBUG flag from all compile statements
-        bad_flag = "-DNDEBUG"
-        for k, v, in list(compiler.__dict__.items()):
-            try:
-                v.remove(bad_flag)
-            except (AttributeError, TypeError, ValueError):
-                pass
-
-        return compiler
-
-    def run(self):
-        print("##################################################")
-        compiler = self._get_compiler()
-        extra_postargs = ["-std=c99", "-pedantic",
-                          "-Wextra", "-Wno-missing-field-initializers",
-                          "-DH5_NO_DEPRECATED_SYMBOLS"]
-
-        # Compile and link any sources that are passed in
-        output_dir = os.path.join(self.build_dir, arch)
-        try:
-            binaries = []
-            for bin, srcs in self.scripts.items():
-                # Only compile srcs with c files
-                try:
-                    if not any([src.endswith(".c") for src in srcs]):
-                        continue
-                except AttributeError:
-                    if not src.endswith(".c"):
-                        continue
-
-                objs = compiler.compile(srcs, output_dir=output_dir,
-                                        include_dirs=include_dirnames,
-                                        extra_postargs=extra_postargs,
-                                        debug=False)
-
-                bin_path = os.path.join(output_dir, bin)
-
-                compiler.link_executable(objs, bin_path,
-                                         library_dirs=library_dirnames)
-                binaries.append(bin_path)
-
-            # Replace dict script with actual before build_scripts.run() call
-            self.scripts = binaries
-        except AttributeError:  # Not a dict
-            pass
-
-        print("##################################################")
-
-        build_scripts.run(self)  # Call actual script
-
-        # If success, remove script build dir
-        if os.path.isdir(output_dir):
-            print("Removing script build dir: %s" % output_dir)
-            rmtree(output_dir)
-
-
-def make_gnulib():
-    print(">> Not a Linux system: configuring and making Gnulib libraries...")
-
-    libfilename = "%s/libgnu.a" % GNULIB_LIB_DIR
-    if os.path.isfile(libfilename):
-        print(">> Found libgnu.a... skipping configure and make")
-    else:
-        commands = ["./configure", "make"]
-        for command in commands:
-            print(">> %s" % command)
-            try:
-                check_call(command, cwd=GNULIB_BUILD_DIR)
-            except CalledProcessError:
-                raise InstallationError("Error compiling Gnulib")
-
-    if not os.path.isfile(libfilename):
-        raise InstallationError("Expected to find: %s" % libfilename)
-
-    to_rm = ["%s/getopt.h" % GNULIB_LIB_DIR]
-    for filename in to_rm:
-        if os.path.isfile(filename):
-            print(">> Removing: %s" % filename)
-            os.remove(filename)
-
-    print(">> Gnulib libraries successfully created!")
 
 if __name__ == "__main__":
-    # Configure and make gnulib if not on Linux
-    if include_gnulib:
-        try:
-            make_gnulib()
-        except InstallationError as e:
-            print(">> ERROR: %s" % e, file=sys.stderr)
-            sys.exit(1)
-
     setup(name=name,
           use_scm_version=True,
           description=short_description,
@@ -338,7 +121,6 @@ if __name__ == "__main__":
           packages=find_packages("."),  # including "test"
           include_package_data=True,
           entry_points=entry_points,
-          scripts={"genomedata-load-data": ["src/genomedata_load_data.c"]},
-          cmdclass={"build_scripts": BuildScriptWrapper,
-                    "clean": CleanWrapper}
+          ext_package= "genomedata", # place extension in the base genomedata package
+          ext_modules=[load_data_module]
           )

--- a/src/_c_load_data.c
+++ b/src/_c_load_data.c
@@ -126,7 +126,7 @@ static PyObject* load_data_from_stdin(PyObject* self, PyObject* args) {
   const char* trackname;
   int verbose; /* needs to be int, not bool for parsing */
 
-  if (!PyArg_ParseTuple(args, "ssp", &gdfilename, &trackname, &verbose)) /* string string bool predicate */
+  if (!PyArg_ParseTuple(args, "ssp", &gdfilename, &trackname, &verbose)) /* string string predicate */
     return NULL;
 
   load_data(gdfilename, trackname, (bool)verbose);

--- a/src/genomedata_load_data.c
+++ b/src/genomedata_load_data.c
@@ -14,6 +14,8 @@
 #define _GNU_SOURCE
 #define __STDC_FORMAT_MACROS
 
+#undef NDEBUG /* Keep assert macros from becoming NOP */
+
 #include <assert.h>
 #include <error.h>
 #include <inttypes.h>
@@ -141,14 +143,14 @@ static PyMethodDef loadDataMethods[] = {
 
 static struct PyModuleDef loadDataModule = {
     PyModuleDef_HEAD_INIT,
-    "_load_data_c_ext", /* name of module */
+    "_c_load_data", /* name of module */
     NULL,               /* module documentation, may be NULL */
     -1,                 /* size of per-interpreter state of the module,
           or -1 if the module keeps state in global variables. */
     loadDataMethods };
 
 PyMODINIT_FUNC
-PyInit__load_data_c_ext(void) /* name is important for ref on import */
+PyInit__c_load_data(void) /* name is important for ref on import */
 {
   return PyModule_Create(&loadDataModule);
 }

--- a/src/genomedata_load_data.c
+++ b/src/genomedata_load_data.c
@@ -121,7 +121,7 @@ void load_data(char* gdfilename, char* trackname, bool verbose);
 
 static PyObject* load_data_from_stdin(PyObject* self, PyObject* args) {
   const char* gdfilename;
-  const char* trackname = "dummy";
+  const char* trackname;
   int verbose; /* needs to be int, not bool for parsing */
 
   if (!PyArg_ParseTuple(args, "ssp", &gdfilename, &trackname, &verbose)) /* string string bool predicate */
@@ -133,24 +133,24 @@ static PyObject* load_data_from_stdin(PyObject* self, PyObject* args) {
   Py_RETURN_NONE;
 }
 
-static PyMethodDef LoadDataMethods[] = {
+static PyMethodDef loadDataMethods[] = {
     {"load_data_from_stdin", load_data_from_stdin, METH_VARARGS,
      "Loads data in BED or WIG format from stdin into a track in a genomedata archive"},
     {NULL, NULL, 0, NULL} /* Sentinel */
 };
 
-static struct PyModuleDef loadDateModule = {
+static struct PyModuleDef loadDataModule = {
     PyModuleDef_HEAD_INIT,
     "_load_data_c_ext", /* name of module */
     NULL,               /* module documentation, may be NULL */
     -1,                 /* size of per-interpreter state of the module,
           or -1 if the module keeps state in global variables. */
-    LoadDataMethods };
+    loadDataMethods };
 
 PyMODINIT_FUNC
 PyInit__load_data_c_ext(void) /* name is important for ref on import */
 {
-  return PyModule_Create(&loadDateModule);
+  return PyModule_Create(&loadDataModule);
 }
 
 /** helper functions **/


### PR DESCRIPTION
This PR replaces genomedata-load-data, which was previously a built c binary through distutils to a python script that calls an entry point into a python extension implemented a c shared library.

This has some immediate benefits:

1. Development can be done in edit mode now. `pip install -e .` works and enables debugging on the extension as well.
2. Removal of all distutils undocumented extensions and hooks to get the binary building through a pip install
3. Distribution can be done by using `wheels` which should simplify and speed up installation.
4. Net removal of code.

Some important notes:

1. Python 2 support might be tenuous due to usage of the C Python API.
2. The interface to `genomedata-load-data` is slightly different in formatting and help text. It also currently does not have `-?` as an option for `--help` while the previous binary version did.
3. The extension must be compiled currently with the additional `-UNDEBUG` to keep current `assert` macros from compiling out since they wrap function calls with side effects that also have return values.
4. This currently is implemented as a drop-in replacement for the previous `genomedata-load-data` and as such the c-extension function call reads directly from stdin and was marked with an underscore to notify that it's generally not a good python function to call.
5.  Other systems *might* be able to be supported. Currently there is no way to test this but as far as I can tell the code looks to be mostly platform agnostic but there's no testing capacity. Notably, the gnulib library has not been fully removed though it seems optional to get the extension building on Linux-based systems.

## Profiling
### Python C extension
```
$ time ./create_H3K4me1_archive.sh 
+ CELL=DOHH2
+ MARKS=(H3K4me1)
+ ACCESSIONS=(ENCFF509XSM)
+ for i in ${!MARKS[@]}
+ ACCESSION=ENCFF509XSM
+ MARK=H3K4me1
+ genomedata-load --assembly --sequence 'chr*.agp.gz' --assembly-report GCA_000001405.28_GRCh38.p13_assembly_report.txt --track H3K4me1=ENCFF509XSM_DOHH2_H3K4me1.bigWig --maskfile k36_umap_multiread_filtered.bed ENCFF509XSM_DOHH2_H3K4me1_test.genomedata

real    13m8.923s
user    14m0.478s
sys     0m54.084s
```
### C Binary
```
$ time ./create_H3K4me1_archive.sh 
+ CELL=DOHH2
+ MARKS=(H3K4me1)
+ ACCESSIONS=(ENCFF509XSM)
+ for i in ${!MARKS[@]}
+ ACCESSION=ENCFF509XSM
+ MARK=H3K4me1
+ genomedata-load --assembly --sequence 'chr*.agp.gz' --assembly-report GCA_000001405.28_GRCh38.p13_assembly_report.txt --track H3K4me1=ENCFF509XSM_DOHH2_H3K4me1.bigWig --maskfile k36_umap_multiread_filtered.bed ENCFF509XSM_DOHH2_H3K4me1_test.genomedata

real    13m58.493s
user    14m51.622s
sys     1m3.137s
```
There does not seem to be a significant change in performance from a cursory profiling test.