### PR TITLE
Flake8 lint fix

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -23,7 +23,7 @@ jobs:
           pip install flake8
       - name: Lint with flake8
         run: |
-          flake8 . --count --statistics
+          flake8 . --exclude 'doc/conf.py examples/*' --count --statistics
       - name: Build repository
         run: |
           python3 -m pip install --verbose .

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -18,6 +18,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install test dependencies
+        run: |
+        pip install flake8
+      - name: Lint with flake8
+        run: |
+        flake8 . --count --statistics
       - name: Build repository
         run: |
           python3 -m pip install --verbose .

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install test dependencies
         run: |
-        pip install flake8
+          pip install flake8
       - name: Lint with flake8
         run: |
-        flake8 . --count --statistics
+          flake8 . --count --statistics
       - name: Build repository
         run: |
           python3 -m pip install --verbose .

--- a/genomedata/__init__.py
+++ b/genomedata/__init__.py
@@ -25,7 +25,7 @@ import sys
 from warnings import warn
 
 import tables
-from numpy import (add, amin, amax, append, array, empty, float32, inf,
+from numpy import (add, amin, amax, array, empty, float32, inf,
                    nan, ndarray, square, uint8)
 from path import Path
 from six import viewitems
@@ -55,6 +55,7 @@ SUFFIX = extsep + EXT
 # more than this many, it will be a single file by default.
 FILE_MODE_CHROMS = 100
 
+
 class _InactiveDict(dict):
     """A fake dict that can't be added to."""
     def __setitem__(self, key, value):
@@ -63,8 +64,9 @@ class _InactiveDict(dict):
 
 def _open_file(filename, *args, **kwargs):
     # From pytables 3 docs:
-    # [open_file] recognizes the (lowercase) names of parameters present in tables/parameters.py
-    if not "buffer_times" in kwargs:
+    # [open_file] recognizes the (lowercase) names of parameters present in
+    # tables/parameters.py
+    if "buffer_times" not in kwargs:
         # eliminate spurious PerformanceWarning
         kwargs["buffer_times"] = inf
 
@@ -92,17 +94,17 @@ class Genome(object):
 
     """
     def __init__(self, filename, *args, **kwargs):
-        """Create a Genome object from a genomdata archive.
+        r"""Create a Genome object from a genomdata archive.
 
         :param filename: the root of the Genomedata object
                          hierarchy. This can either be a .genomedata
                          file that contains the entire genome or a
                          directory containing multiple chromosome files.
         :type filename: string
-        :param \*args: args passed on to open_file if single file or to
-                       Chromosome if directory
-        :param \*\*kwargs: keyword args passed on to open_file if single file
-                           or to Chromosome if directory
+        :param *args: args passed on to open_file if single file or to
+                      Chromosome if directory
+        :param **kwargs: keyword args passed on to open_file if single file
+                         or to Chromosome if directory
 
         Example:
 
@@ -569,7 +571,7 @@ since being closed with genomedata-close-data.""")
 
     @classmethod
     def _fromfilename(cls, filename, mode=default_mode, *args, **kwargs):
-        """
+        r"""
         :param filename: name of the chromosome (.genomedata) file to access
 
         :param mode: mode of interaction with the chromosome file,
@@ -578,8 +580,8 @@ since being closed with genomedata-close-data.""")
                      for tables.open_file().)
 
         :type mode: string
-        :param \*args: args passed on to open_file
-        :param \*\*kwargs: keyword args passed on to open_file
+        :param *args: args passed on to open_file
+        :param **kwargs: keyword args passed on to open_file
 
         """
         filepath = Path(filename).expand()
@@ -829,8 +831,8 @@ since being closed with genomedata-close-data.""")
 
         # Check if the given region overlaps with any gap in the assembly
         self._check_region_inside_supercontigs(supercontigs,
-                                                 base_key.start,
-                                                 base_key.stop)
+                                               base_key.start,
+                                               base_key.stop)
 
         # For each supercontig
         for supercontig in supercontigs:
@@ -933,7 +935,7 @@ since being closed with genomedata-close-data.""")
         if self.attrs.dirty:
             warn("Closing Chromosome with modified data. Metadata needs to"
                  " be recalculated by calling genomedata-close-data on the"
-                 " Genomedata archive before re-accessing it", 
+                 " Genomedata archive before re-accessing it",
                  category=GenomedataDirtyWarning)
 
         if self._isfile:
@@ -968,7 +970,7 @@ since being closed with genomedata-close-data.""")
 
         """
         self.attrs.dirty = True  # dirty specific to chromosome
-        # Add the trackname to the chromosome before 
+        # Add the trackname to the chromosome before
         add_trackname(self, trackname)
 
         # Extend supercontigs by a column (or create them)
@@ -1362,6 +1364,7 @@ def _key_to_tuple(key):
 
 def main(argv=sys.argv[1:]):
     pass
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/genomedata/_close_data.py
+++ b/genomedata/_close_data.py
@@ -85,13 +85,15 @@ def find_next_present_coord(chromosome, start_supercontig):
                 col = continuous[:, col_index]
                 mask_present = isfinite(col)
                 # If there is any value present
-                if any(mask_present):  # mask_present is boolean "present" array
+                if any(mask_present):  # mask_present is a bool "present" array
                     # Get the earliest coordinate
-                    # NB: argmax gives the index of the maximum value. In the case
-                    # of ties (which there will be) argmax returns the first index
-                    # with the maximum value. I believe this is the recommended
-                    # (and fastest?) way of finding the first occurrence of a value
-                    first_present_coord = supercontig.start + argmax(mask_present)
+                    # NB: argmax gives the index of the maximum value. In the
+                    # case of ties (which there will be) argmax returns the
+                    # first index with the maximum value. I believe this is the
+                    # recommended (and fastest?) way of finding the first
+                    # occurrence of a value
+                    first_present_coord = (supercontig.start +
+                                           argmax(mask_present))
                     if not res:
                         res = first_present_coord
                     else:
@@ -128,7 +130,7 @@ def trim_chunks_start(prev_supercontig, prev_end_coord,
         # If the distance between previous and current present data
         # chromsomal positions is greater than MIN_GAP_LEN
         if (first_present_value_coord - prev_end_coord >
-            MIN_GAP_LEN):
+                MIN_GAP_LEN):
             # Truncate the start chunk of the supercontig to start
             # where data is present
             res = first_present_value_index
@@ -148,7 +150,7 @@ def trim_chunks_end(next_supercontig, next_start_coord,
 
     # NB: this is unchanged if the distance between the last
     # present coordinate and the next present coordinate is less
-    # than MIN_GAP_LEN 
+    # than MIN_GAP_LEN
     res = chunk_end_index
 
     # NB: argmax will give the index of the first element on matching
@@ -164,7 +166,7 @@ def trim_chunks_end(next_supercontig, next_start_coord,
         # or there is no next possible present value
         if (not next_start_coord or
             next_start_coord - last_present_chrom_coord >
-            MIN_GAP_LEN):
+                MIN_GAP_LEN):
             # Truncate the chunk end to where data is last present in
             # this supercontig
             res = last_present_index
@@ -197,7 +199,6 @@ def write_metadata(chromosome, verbose=False):
     num_datapoints = fill_array(0, row_shape)
 
     supercontigs = chromosome.supercontigs[chromosome.start:chromosome.end]
-    num_supercontigs = len(supercontigs)
     prev_chrom_end = 0  # keeps track of where data was last present
 
     prev_supercontigs = [None] + supercontigs[:-1]
@@ -231,7 +232,7 @@ def write_metadata(chromosome, verbose=False):
             if verbose:
                 print("  %s" % trackname, file=sys.stderr)
 
-            ## read data
+            # read data
             col = continuous[:, col_index]
 
             mask_present = isfinite(col)
@@ -251,7 +252,7 @@ def write_metadata(chromosome, verbose=False):
         supercontig_attrs = supercontig.attrs
 
         next_chrom_start = find_next_present_coord(chromosome,
-                                                    next_supercontig)
+                                                   next_supercontig)
 
         # If any data is present in this supercontig
         if any(mask_rows_any_present):

--- a/genomedata/_erase_data.py
+++ b/genomedata/_erase_data.py
@@ -15,6 +15,7 @@ from . import Genome, __version__
 
 LINE_WIDTH = 70
 
+
 def erase_data(gdfilename, trackname, verbose=False):
     if verbose:
         print("Erasing data for track: %s." % trackname, file=sys.stderr)
@@ -35,6 +36,7 @@ def erase_data(gdfilename, trackname, verbose=False):
         if verbose:
             print("\ndone", file=sys.stderr)
 
+
 def parse_options(args):
 
     description = ("Erase the specified tracks from the Genomedata archive"
@@ -48,7 +50,7 @@ def parse_options(args):
 
     parser.add_argument('gdarchive', help='genomedata archive')
 
-    parser.add_argument("--trackname", required=True, nargs='+', 
+    parser.add_argument("--trackname", required=True, nargs='+',
                         help="tracknames to erase")
 
     parser.add_argument("--verbose", default=False, action="store_true",
@@ -58,12 +60,14 @@ def parse_options(args):
 
     return args
 
+
 def main(argv=sys.argv[1:]):
     args = parse_options(argv)
     gdarchive = args.archive
 
     for trackname in args.tracknames:
         erase_data(gdarchive, trackname, verbose=args.verbose)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/genomedata/_hardmask.py
+++ b/genomedata/_hardmask.py
@@ -18,7 +18,7 @@ from numpy import full, nan
 from ._close_data import write_genome_metadata
 from ._util import EXT_GZ, maybe_gzip_open
 from ._hardmask_parsers import (get_bed_filter_region, get_wig_filter_region,
-                                  merged_filter_region_generator)
+                                merged_filter_region_generator)
 from . import Genome, __version__
 
 BED_FILETYPE = "bed"
@@ -151,8 +151,8 @@ def parse_hardmask_option(mask_option):
         # Attempt to convert the filter value into a number
         mask_value = float(mask_value)
         # Get the function associated with this operator and given value
-        hard_mask_function = partial(HARDMASK_OPERATORS[mask_operator],
-                                     mask_value)
+        hardmask_function = partial(HARDMASK_OPERATORS[mask_operator],
+                                    mask_value)
     # Otherwise display an error about the operator
     except KeyError:
         raise ValueError("The operator {} is not understood or "
@@ -162,8 +162,8 @@ def parse_hardmask_option(mask_option):
 
 
 def main():
-    description = ("Permanently mask TRACKNAME(s) from a genomedata archive with "
-                   "MASKFILE using an optional filter operator.")
+    description = ("Permanently mask TRACKNAME(s) from a genomedata archive "
+                   "with MASKFILE using an optional filter operator.")
     parser = argparse.ArgumentParser(description=description,
                                      prog="genomedata-hard-mask")
 
@@ -206,8 +206,8 @@ def main():
         hardmask_function = None
 
     hardmask_data(gd_filename, mask_filename, track_names,
-                   hardmask_function, is_verbose, keep_archive_open,
-                   is_dry_run)
+                  hardmask_function, is_verbose, keep_archive_open,
+                  is_dry_run)
 
 
 if __name__ == "__main__":

--- a/genomedata/_histogram.py
+++ b/genomedata/_histogram.py
@@ -99,5 +99,6 @@ def main(argv=sys.argv[1:]):
     return _histogram(args.gdarchive, args.trackname, args.num_bins,
                       args.include_coords)
 
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/genomedata/_info.py
+++ b/genomedata/_info.py
@@ -68,5 +68,6 @@ def main(argv=sys.argv[1:]):
 
     return _info(args.command, args.gdarchive)
 
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/genomedata/_load_data.py
+++ b/genomedata/_load_data.py
@@ -3,7 +3,8 @@
 from __future__ import absolute_import, division, print_function
 
 """
-_load_data.py: A python interface for both genomedata_load_data.c and load_genomedata.py
+_load_data.py: A python interface for both genomedata_load_data.c and
+load_genomedata.py
 """
 
 import struct
@@ -24,7 +25,8 @@ BEDTOOLS_INTERSECT_CMD = "intersect"
 BEDTOOLS_STDIN = "stdin"
 DEFAULT_CHUNK_SIZE = 10000
 LOAD_DATA_CMD = "genomedata-load-data"
-MSG_LOAD_ERROR = "Error loading data from track file %%s. %s returned %%s." % LOAD_DATA_CMD
+MSG_LOAD_ERROR = ("Error loading data from track file %%s. " +
+                  "{} returned %%s.".format(LOAD_DATA_CMD))
 
 
 def load_data(gdfilename, trackname, datafile, maskfile=None, verbose=False):
@@ -147,14 +149,15 @@ def parse_args(args):
 
     parser = ArgumentParser(description=description,
                             prog='genomedata-load-data')
-    
-    parser.add_argument('-V', '--version', action='version', version=__version__)
+
+    parser.add_argument('-V', '--version', action='version',
+                        version=__version__)
 
     parser.add_argument('gdarchive', help='genomedata archive')
     parser.add_argument('trackname', help='track name')
 
     parser.add_argument("-v", "--verbose", default=False, action="store_true",
-                      help="Print status and diagnostic messages")
+                        help="Print status and diagnostic messages")
 
     args = parser.parse_args(args)
 
@@ -164,6 +167,7 @@ def parse_args(args):
 def main(argv=sys.argv[1:]):
     args = parse_args(argv)
     load_data_from_stdin(args.gdarchive, args.trackname, args.verbose)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/genomedata/_load_seq.py
+++ b/genomedata/_load_seq.py
@@ -28,11 +28,11 @@ from ._util import (chromosome_name_map_parser,
                     ignore_comments, LightIterator, maybe_gzip_open)
 
 MIN_GAP_LEN = 100000
-assert not MIN_GAP_LEN % 2 # must be even for division
+assert not MIN_GAP_LEN % 2  # must be even for division
 
 # sre_constants.MAXREPEAT is 65535, so I have to break repeats into
 # two segments
-REGEX_SEGMENT_LEN = MIN_GAP_LEN // 2 # max == MAXREPEAT
+REGEX_SEGMENT_LEN = MIN_GAP_LEN // 2  # max == MAXREPEAT
 
 DNA_LETTERS_UNAMBIG = "ACGTacgt"
 
@@ -50,6 +50,7 @@ GAP_COMPONENT_TYPES = frozenset("NU")
 
 GenomicPosition = uint32
 GENOMIC_POSITION_0 = GenomicPosition(0)
+
 
 def read_agp(iterable):
     """
@@ -134,6 +135,7 @@ def create_supercontig(chromosome, index, seq=None, start=None, end=None):
     attrs.start = GenomicPosition(start)
     attrs.end = GenomicPosition(end)
 
+
 # XXXopt: the all-regex approach is much slower than the hybrid
 # approach (3 min to load chr21, 6 min to load chr1), but it is easier
 # to understand the code and get it correct
@@ -152,16 +154,20 @@ re_gap_segment = compile(r"""
        DNA_LETTERS_UNAMBIG, REGEX_SEGMENT_LEN-1,
        DNA_LETTERS_UNAMBIG), VERBOSE)
 
+
 def init_chromosome_start(chromosome):
     """
-    doesn't set end, so you can't use create_supercontig(end=None) if you use this
+    doesn't set end, so you can't use create_supercontig(end=None) if you use
+    this
     """
     chromosome.attrs.start = GENOMIC_POSITION_0
     chromosome._file_attrs.genomedata_format_version = FORMAT_VERSION
 
+
 def init_chromosome(chromosome, size):
     init_chromosome_start(chromosome)
     chromosome.attrs.end = GenomicPosition(size)
+
 
 def read_seq(chromosome, seq):
     supercontig_index = 0
@@ -178,6 +184,7 @@ def read_seq(chromosome, seq):
         else:
             assert m_segment.group(1)
 
+
 def read_assembly(chromosome, infile):
     supercontig_index = 0
 
@@ -193,9 +200,11 @@ def read_assembly(chromosome, infile):
 
     chromosome.attrs.end = GenomicPosition(end)
 
+
 def size_chromosome(chromosome, size):
     init_chromosome(chromosome, size)
     create_supercontig(chromosome, 0)
+
 
 def load_sizes(filename):
     res = {}
@@ -206,6 +215,7 @@ def load_sizes(filename):
             res[row[0]] = int(row[1])
 
     return res
+
 
 def get_num_seq(filenames):
     """
@@ -238,15 +248,16 @@ def read_chromosome_name_map(assembly_report_file):
 
     # Retrive the string after the comment delimiter and split on whitespace
     # for the header fields
-    header_fields = \
-    header_line.partition(ASSEMBLY_REPORT_COMMENT_DELIMITER)[2].strip().split()
+    header_fields = header_line.partition(
+        ASSEMBLY_REPORT_COMMENT_DELIMITER)[2].strip().split()
 
     # Return a dictionary with header fields for keys containing a list for
     # their respective column
     for header_field in header_fields:
         res[header_field] = []
 
-    for row in csv.DictReader(assembly_report_lines[header_index+1:], header_fields,
+    for row in csv.DictReader(assembly_report_lines[header_index+1:],
+                              header_fields,
                               delimiter=ASSEMBLY_REPORT_FIELD_DELIMITER):
         for header_field in header_fields:
             res[header_field].append(row[header_field])
@@ -316,7 +327,7 @@ def create_chromosome(genome, name, mode):
     name = "_".join(name.split())  # Remove any whitespace
     if mode == "dir":
         res = genome[name]
-    else: # mode == "file"
+    else:  # mode == "file"
         h5file = genome.h5file
         h5file.create_group("/", name, filters=FILTERS_GZIP)
         res = genome[name]
@@ -325,19 +336,20 @@ def create_chromosome(genome, name, mode):
 
     return res
 
+
 def load_seq(gdfilename, filenames, verbose=False, mode=None,
              seqfile_type="fasta", assembly_report_file=None,
              chromosome_name_style=DEFAULT_CHROMOSOME_NAME_STYLE):
     gdpath = Path(gdfilename)
 
-    ## load sizes if necessary to figure out number of chromosomes
+    # load sizes if necessary to figure out number of chromosomes
     if seqfile_type == "sizes":
         assert len(filenames) == 1
         sizes = load_sizes(filenames[0])
     else:
         sizes = None
 
-    ## decide whether should use dir or file mode
+    # decide whether should use dir or file mode
     if mode is None:
         if seqfile_type == "sizes":
             num_seq = len(sizes)
@@ -404,10 +416,12 @@ def load_seq(gdfilename, filenames, verbose=False, mode=None,
                             # For every AGP line
                             agp_object_index = AGP_FIELDNAMES.index("object")
                             for agp_line in agp_lines:
-                                chr_name = agp_line.split("\t")[agp_object_index]
+                                chr_name = \
+                                    agp_line.split("\t")[agp_object_index]
 
                                 # Add the line by chromsome name in the dict
-                                agp_chromosome_buffer[chr_name].append(agp_line)
+                                agp_chromosome_buffer[chr_name].append(
+                                    agp_line)
 
                             # For each chromosome and its agp lines
                             for chromosome_name in agp_chromosome_buffer:
@@ -421,16 +435,20 @@ def load_seq(gdfilename, filenames, verbose=False, mode=None,
                                 # Read the assembly in to the chromosome entry
                                 # in genomedata
                                 read_assembly(chromosome,
-                                              agp_chromosome_buffer[chromosome_name])
+                                              agp_chromosome_buffer[
+                                                  chromosome_name])
 
                         else:
                             for defline, seq in LightIterator(infile):
-                                name = get_chromosome_name(defline,
-                                chromosome_name_map, chromosome_name_style)
+                                name = get_chromosome_name(
+                                    defline,
+                                    chromosome_name_map,
+                                    chromosome_name_style)
 
                                 chromosome = create_chromosome(genome, name,
                                                                mode)
                                 read_seq(chromosome, seq)
+
 
 def parse_options(args):
 
@@ -442,7 +460,7 @@ def parse_options(args):
     parser = ArgumentParser(description=description,
                             parents=[chromosome_name_map_parser],
                             prog='genomedata-load-seq')
-    
+
     parser.add_argument('--version', action='version', version=__version__)
 
     parser.add_argument('gdarchive', help='genomedata archive')
@@ -461,11 +479,12 @@ def parse_options(args):
     parser.add_argument("-f", "--file-mode", dest="mode",
                         default=None, action="store_const", const="file",
                         help="If specified, the Genomedata archive will be"
-                        " implemented as a single file, with a separate h5 group"
-                        " for each Chromosome. This is recommended if there are"
-                        " a large number of Chromosomes. The default behavior is"
-                        " to use a single file if there are at least %s"
-                        " Chromosomes being added." % FILE_MODE_CHROMS)
+                        " implemented as a single file, with a separate h5"
+                        " group for each Chromosome. This is recommended if"
+                        " there are a large number of Chromosomes. The default"
+                        " behavior is to use a single file if there are at"
+                        " least %s Chromosomes being added." %
+                        FILE_MODE_CHROMS)
     parser.add_argument("-d", "--directory-mode", dest="mode",
                         action="store_const", const="dir",
                         help="If specified, the Genomedata archive will be"
@@ -474,12 +493,13 @@ def parse_options(args):
                         " small number of Chromosomes. The default behavior is"
                         " to use a directory if there are fewer than %s"
                         " Chromosomes being added." % FILE_MODE_CHROMS)
-    parser.add_argument("--verbose",default=False, action="store_true",
-                      help="Print status updates and diagnostic messages")
+    parser.add_argument("--verbose", default=False, action="store_true",
+                        help="Print status updates and diagnostic messages")
 
     args = parser.parse_args(args)
 
     return args
+
 
 def main(argv=sys.argv[1:]):
     args = parse_options(argv)
@@ -488,6 +508,7 @@ def main(argv=sys.argv[1:]):
                     mode=args.mode, seqfile_type=args.seqfile_type,
                     assembly_report_file=args.assembly_report,
                     chromosome_name_style=args.name_style)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/genomedata/_open_data.py
+++ b/genomedata/_open_data.py
@@ -60,5 +60,6 @@ def main(argv=sys.argv[1:]):
     args = parse_options(argv)
     return open_data(args.gdarchive, args.tracknames, verbose=args.verbose)
 
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/genomedata/_query.py
+++ b/genomedata/_query.py
@@ -14,6 +14,7 @@ from argparse import ArgumentParser
 
 from . import Genome, __version__
 
+
 def _query(filename, trackname, chromosome_name, begin, end):
 
     with Genome(filename) as genome:
@@ -31,7 +32,7 @@ def parse_options(args):
 
     parser = ArgumentParser(prog='genomedata-query',
                             description=description)
-    
+
     parser.add_argument('--version', action='version', version=__version__)
     parser.add_argument('gdarchive', help='genomedata archive')
     parser.add_argument('trackname', help='track name')
@@ -49,6 +50,7 @@ def main(argv=sys.argv[1:]):
 
     return _query(args.gdarchive, args.trackname, args.chrom,
                   args.begin, args.end)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/genomedata/_report.py
+++ b/genomedata/_report.py
@@ -16,6 +16,7 @@ from argparse import ArgumentParser
 from . import Genome, __version__
 from tabdelim import ListWriter
 
+
 def report(gdarchive):
     writer = ListWriter()
 
@@ -23,6 +24,7 @@ def report(gdarchive):
         writer.writerow(["measurement"] + genome.tracknames_continuous)
         writer.writerow(["mean"] + list(genome.means))
         writer.writerow(["var"] + list(genome.vars))
+
 
 def parse_options(args):
 

--- a/genomedata/_util.py
+++ b/genomedata/_util.py
@@ -10,9 +10,8 @@ from gzip import open as _gzip_open
 from os import extsep
 import sys
 
-from numpy import append, array, empty, nan
-from tables import Filters, Float32Atom, NoSuchNodeError
-
+from numpy import append, array, empty
+from tables import Filters
 
 
 FILTERS_GZIP = Filters(complevel=1)
@@ -20,12 +19,13 @@ FILTERS_GZIP = Filters(complevel=1)
 EXT_GZ = "gz"
 SUFFIX_GZ = extsep + EXT_GZ
 
-GENOMEDATA_ENCODING="ascii"
+GENOMEDATA_ENCODING = "ascii"
 
 DEFAULT_CHROMOSOME_NAME_STYLE = "UCSC-style-name"
 
 chromosome_name_map_parser = ArgumentParser(add_help=False)
-chromsome_names = chromosome_name_map_parser.add_argument_group("Chromosome naming")
+chromsome_names = chromosome_name_map_parser.add_argument_group(
+                  "Chromosome naming")
 chromsome_names.add_argument(
     "-r", "--assembly-report",
     dest="assembly_report", type=FileType('r'),
@@ -43,6 +43,7 @@ chromsome_names.add_argument(
 def die(msg="Unexpected error."):
     print(msg, file=sys.stderr)
     sys.exit(1)
+
 
 class LightIterator(object):
     def __init__(self, handle):
@@ -76,12 +77,15 @@ class LightIterator(object):
             raise StopIteration
 
         if defline_old is None:
-            raise ValueError("no definition line found at next position in %r" % self._handle)
+            raise ValueError(
+                "no definition line found at next position in %r"
+                % self._handle)
 
         return defline_old, ''.join(lines)
 
     def next(self):
         return self.__next__()
+
 
 # XXX: suggest as default
 def fill_array(scalar, shape, dtype=None, *args, **kwargs):
@@ -93,21 +97,25 @@ def fill_array(scalar, shape, dtype=None, *args, **kwargs):
 
     return res
 
+
 # XXX: suggest as default
 def gzip_open(*args, **kwargs):
     return closing(_gzip_open(*args, **kwargs))
 
+
 def maybe_gzip_open(filename, mode="rt", *args, **kwargs):
-    if filename.endswith(SUFFIX_GZ): 
+    if filename.endswith(SUFFIX_GZ):
         return gzip_open(filename, mode=mode, *args, **kwargs)
     else:
         return open(filename, mode=mode, *args, **kwargs)
+
 
 def init_num_obs(num_obs, continuous):
     curr_num_obs = continuous.shape[1]
     assert num_obs is None or num_obs == curr_num_obs
 
     return curr_num_obs
+
 
 def new_extrema(func, data, extrema):
     curr_extrema = func(data, 0)
@@ -118,11 +126,15 @@ def new_extrema(func, data, extrema):
 def ignore_comments(iterable):
     return (item for item in iterable if not item.startswith("#"))
 
+
 def decode_tracknames(gdfile):
-    return [trackname.decode(GENOMEDATA_ENCODING) for trackname in gdfile._file_attrs.tracknames]
+    return [trackname.decode(GENOMEDATA_ENCODING)
+            for trackname in gdfile._file_attrs.tracknames]
+
 
 def add_trackname(gdfile, trackname):
-    # gdfile can refer to either a file for the whole genome or a single chromosome 
+    # gdfile can refer to either a file for the whole genome or a
+    # single chromosome
     assert gdfile.isopen
     if gdfile._isfile:
         # Update tracknames attribute with new trackname
@@ -138,14 +150,18 @@ def add_trackname(gdfile, trackname):
         file_attrs.tracknames = append(tracknames,
                                        trackname.encode(GENOMEDATA_ENCODING))
 
+
 class GenomedataDirtyWarning(UserWarning):
     pass
+
 
 class OverlapWarning(UserWarning):
     pass
 
+
 def main(args=sys.argv[1:]):
     pass
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ genomedata-report = genomedata._report:main
 genomedata-erase-data = genomedata._erase_data:main
 """
 
-setup_requires = ["setuptools_scm"] # source control management packaging
+setup_requires = ["setuptools_scm"]  # source control management packaging
 # Exclude PyTables 3.4.1 - incorrect binary distribution causes core dumps
 # See:
 # https://bitbucket.org/hoffmanlab/genomedata/issues/38/pytables-341-causes-a-core-dump-when
@@ -70,8 +70,9 @@ setup_requires = ["setuptools_scm"] # source control management packaging
 install_requires = ["numpy", "tables>=3.0,!=3.4.1", "six",
                     "textinput>=0.2.0", "path.py>=11"]
 
-# Monkey patches tokenize.detect_encoding() to return a blank string when it can't recognize encoding
-# setuptools attempts to process some of the C files present, and errors because it can't determine encoding
+# Monkey patches tokenize.detect_encoding() to return a blank string when it
+# can't recognize encoding setuptools attempts to process some of the C files
+# present, and errors because it can't determine encoding
 try:
     _detect_encoding = tokenize.detect_encoding
 except AttributeError:
@@ -85,11 +86,13 @@ else:
     tokenize.detect_encoding = detect_encoding
 
 source_files = ["src/_c_load_data.c"]
-# sz may be needed here if it's statically builtin with an hdf5 distribution? Or someone built their own hdf5 version with sz in which case they should rely on using LD_LIBRARY_PATH?
-libs = ["hdf5", "m", "z"] # hdf5, math, zlib, (sz? lossless compression libray for scientific data)
+# sz may be needed here if it's statically builtin with an hdf5 distribution?
+# Or someone built their own hdf5 version with sz in which case they should
+# rely on using LD_LIBRARY_PATH?
+libs = ["hdf5", "m", "z"]  # hdf5, math, zlib, (sz?)
 library_dirnames = []
 include_dirnames = [
-    sysconfig.get_config_var("INCLUDEDIR"), # environment headers
+    sysconfig.get_config_var("INCLUDEDIR"),  # environment headers
 ]
 c_define_macros = [("H5_NO_DEPRECATED_SYMBOLS", None)]
 
@@ -130,16 +133,17 @@ else:
     for word in pkg_config_libs:
         if not word.startswith(LDFLAGS_LIBRARY_SWITCH):
             assert word.startswith(LDFLAGS_LIBRARY_PATH_SWITCH)
-            library_dirnames.append(word.partition(LDFLAGS_LIBRARY_PATH_SWITCH)[2])
+            library_dirnames.append(
+                word.partition(LDFLAGS_LIBRARY_PATH_SWITCH)[2])
 
 
-load_data_module = Extension('_c_load_data', # needs to match C file PyInit definition
-                            sources=source_files,
-                            include_dirs=include_dirnames,
-                            libraries=libs,
-                            library_dirs=library_dirnames,
-                            define_macros=c_define_macros,
-                            )
+load_data_module = Extension(
+    '_c_load_data',  # needs to match C file PyInit definition
+    sources=source_files,
+    include_dirs=include_dirnames,
+    libraries=libs,
+    library_dirs=library_dirnames,
+    define_macros=c_define_macros)
 
 
 if __name__ == "__main__":
@@ -159,7 +163,8 @@ if __name__ == "__main__":
           packages=find_packages("."),  # including "test"
           include_package_data=True,
           entry_points=entry_points,
-          ext_package="genomedata", # place extension in the base genomedata package
+          # place extension in the base genomedata package
+          ext_package="genomedata",
           ext_modules=[load_data_module],
           python_requires=">={}".format(MINIMUM_PYTHON_VERSION_STR)
           )

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -207,16 +207,15 @@ class TestAGPMerge(unittest.TestCase):
                  self.mode, seqfile_type="agp")
         close_data(self.genomedata_name, self.verbose)
 
-
     def test_merged_agp_regions(self):
         with Genome(self.genomedata_name) as genome:
             # Assume only chr10 is defined
             chromosome = genome["chr10"]
             # The following supercontigs should span the following coordinates:
             expected_supercontig_coordinates = [
-                ( 39239118, 39254773 ),
-                ( 39254793, 39338430 ),
-                ( 39338450, 39341685 ),
+                (39239118, 39254773),
+                (39254793, 39338430),
+                (39338450, 39341685),
             ]
             supercontig_coordinates = []
             # For every supercontig (in chr10)
@@ -244,20 +243,21 @@ class TestChromosomeNameTranslation(unittest.TestCase):
                               test_data_path("chr1.agp.gz")]
         self.mode = "file"
 
-        with open(test_data_path("assembly_report.txt"), "r") as assembly_report_file:
+        with open(test_data_path("assembly_report.txt"), "r") as \
+                assembly_report_file:
             load_seq(self.genomedata_name, self.agp_filenames, self.verbose,
-                    self.mode, seqfile_type="agp",
-                    assembly_report_file=assembly_report_file,
-                    chromosome_name_style="UCSC-style-name")
+                     self.mode, seqfile_type="agp",
+                     assembly_report_file=assembly_report_file,
+                     chromosome_name_style="UCSC-style-name")
 
         close_data(self.genomedata_name, self.verbose)
-
 
     def test_translated_chromsome_names(self):
         chromosome_names = []
 
         with Genome(self.genomedata_name) as genome:
-            # Check to see if chrY from Genbank and chr1 from RefSeq were translated
+            # Check to see if chrY from Genbank and chr1 from RefSeq were
+            # translated
             chromosome_names = [chromosome.name for chromosome in genome]
 
         self.assertIn("chr1", chromosome_names)
@@ -273,6 +273,7 @@ def main():
         chdir(dirpath)
 
     unittest.main()
+
 
 if __name__ == "__main__":
     main()

--- a/test/test_genomedata.py
+++ b/test/test_genomedata.py
@@ -26,13 +26,17 @@ from genomedata._close_data import close_data
 from genomedata._erase_data import erase_data
 from genomedata._hardmask import hardmask_data
 from genomedata._open_data import open_data
-from genomedata._util import GENOMEDATA_ENCODING, GenomedataDirtyWarning, OverlapWarning
-
-test_filename = lambda filename: os.path.join("data", filename)
+from genomedata._util import (GENOMEDATA_ENCODING, GenomedataDirtyWarning,
+                              OverlapWarning)
 
 DEFAULT_TRACK_FILTER_THRESHOLD = 0.5
 UNFILTERED_TRACKNAME = "zunfiltered"
 UNFILTERED_TRACK_FILENAME = "unfiltered.bed"
+
+
+def test_filename(filename):
+    return os.path.join("data", filename)
+
 
 def seq2str(seq):
     return seq.tobytes().decode(GENOMEDATA_ENCODING).lower()
@@ -45,7 +49,8 @@ def make_temp_dir():
 class GenomedataTesterBase(unittest.TestCase):
     def setUp(self):
         # Defaults
-        # XXX: adding verbosity when unittest is run with verbosity would be useful
+        # XXX: adding verbosity when unittest is run with verbosity would be
+        # useful
         self.verbose = False
         self.write = True
         self.mode = "dir"
@@ -78,8 +83,9 @@ class GenomedataTesterBase(unittest.TestCase):
             mode = "r+"
         else:
             mode = "r"
-        # catch_warnings acts as a context manager storing the original warning filter
-        # and resetting it at the end. All non user warnings should still be displayed
+        # catch_warnings acts as a context manager storing the original warning
+        # filter and resetting it at the end. All non user warnings should
+        # still be displayed
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", GenomedataDirtyWarning)
             warnings.simplefilter("ignore", OverlapWarning)
@@ -133,7 +139,6 @@ class GenomedataTesterBase(unittest.TestCase):
                 self.assertArraysEqual(chromosome[290, array([1, 0])],
                                        [-2.327, -2.297])
 
-
                 # Test filling of unassigned continuous segments
                 chromosome = genome["chrY"]
                 # Get first supercontig
@@ -148,7 +153,8 @@ class GenomedataTesterBase(unittest.TestCase):
                     # Test writing scalar to multiple tracks
                     chromosome[290] = 100.0
                     # Test writing scalar to tracks by named list
-                    chromosome[291, ["placental", "primate", "vertebrate"]] = 101.0
+                    chromosome[291,
+                               ["placental", "primate", "vertebrate"]] = 101.0
                     # Test writing scalar to select tracks by named list
                     chromosome[292, ["placental", "vertebrate"]] = 102.0
                     # Test writing scalar to tracks by index
@@ -159,7 +165,8 @@ class GenomedataTesterBase(unittest.TestCase):
                     # Test writing an array to a single index
                     chromosome[295] = [105.0, 106.0, 107.0]
                     # Test writing a subarray to a index subset
-                    chromosome[296, ["placental", "vertebrate"]] = [108.0, 109.0]
+                    chromosome[296,
+                               ["placental", "vertebrate"]] = [108.0, 109.0]
 
                     # Test removing datapoints by writing NaN
                     chromosome[297, ["primate"]] = nan
@@ -190,7 +197,8 @@ class GenomedataTesterBase(unittest.TestCase):
                                        [100.0, 100.0, 100.0])
                 self.assertArraysEqual(chromosome[291],
                                        [101.0, 101.0, 101.0])
-                self.assertArraysEqual(chromosome[292],  # L14 in primate wigFix
+                # L14 in primate wigFix
+                self.assertArraysEqual(chromosome[292],
                                        [102.0, 0.371, 102.0])
                 self.assertArraysEqual(chromosome[293],
                                        [103.0, 0.372, 103.0])
@@ -205,7 +213,6 @@ class GenomedataTesterBase(unittest.TestCase):
                                        [genome.num_datapoints[0],
                                         genome.num_datapoints[1] + 1,
                                         genome.num_datapoints[2]])
-
 
     def test_repr_str(self):
         genome = Genome(self.gdfilepath, mode="r")
@@ -355,15 +362,18 @@ class GenomedataTester(GenomedataTesterBase):
         # Make sure filtering was successful
         genome = Genome(self.gdfilepath)
         with genome:
-            self.assertArraysEqual(genome["chr1"][0:4, UNFILTERED_TRACKNAME],
+            self.assertArraysEqual(genome["chr1"][0:4,
+                                   UNFILTERED_TRACKNAME],
                                    [nan, nan, nan, nan])
-            self.assertArraysEqual(genome["chr1"][128:132, UNFILTERED_TRACKNAME],
+            self.assertArraysEqual(genome["chr1"][128:132,
+                                   UNFILTERED_TRACKNAME],
                                    [nan, nan, 0.5, 0.5])
-            self.assertArraysEqual(genome["chr1"][168:172, UNFILTERED_TRACKNAME],
+            self.assertArraysEqual(genome["chr1"][168:172,
+                                   UNFILTERED_TRACKNAME],
                                    [0.9, 0.9, nan, nan])
-            self.assertArraysEqual(genome["chr1"][206:210, UNFILTERED_TRACKNAME],
+            self.assertArraysEqual(genome["chr1"][206:210,
+                                   UNFILTERED_TRACKNAME],
                                    [nan, nan, nan, nan])
-
 
     def test_delete_tracks(self):
         # Test ability to delete a track
@@ -433,7 +443,7 @@ class GenomedataGivenDataTester(GenomedataTesterBase):
         self.tracknames = ["placental", "primate", "vertebrate"]
 
 
-## XXX: why isn't this a sublcass of GenomeDataTesterBase?
+# XXX: why isn't this a sublcass of GenomeDataTesterBase?
 class GenomedataNoDataTester(unittest.TestCase):
     def setUp(self):
         # Defaults
@@ -548,6 +558,7 @@ def main(args=sys.argv[1:]):
     args = parse_options(args)
 
     return test_genomedata(*args)
+
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
This PR adds flake8 to GitHub actions and fixes all reported flake8 issues in the Genomedata codebase.

Of note there were some bare excepts being used presumably as a catch-all for generic error reporting. These have been replaced with referencing the `Exception` type which allows for any program exception, but not catching any system-style exception (e.g. `KeyboardInterrupt` or `SystemExit`).

This also ignores linting in `examples` directory and inside `doc/conf.py` since that file is largely autogenerated.