### PR TITLE
Add mypy to Genomedata CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install test dependencies
         run: |
-          pip install flake8 mypy
+          pip install flake8 mypy types-six types-pkg_resources
       - name: Lint with flake8
         run: |
           flake8 . --exclude 'doc/conf.py examples/*' --count --statistics

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -20,10 +20,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install test dependencies
         run: |
-          pip install flake8
+          pip install flake8 mypy
       - name: Lint with flake8
         run: |
           flake8 . --exclude 'doc/conf.py examples/*' --count --statistics
+      - name: Type check with mypy
+        run: |
+          mypy genomedata test
       - name: Build repository
         run: |
           python3 -m pip install --verbose .

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -14,7 +14,7 @@ from genomedata._close_data import close_data
 from genomedata.load_genomedata import load_genomedata
 from genomedata import Genome
 
-from . import test_genomedata
+import test_genomedata
 from six.moves import range
 
 """

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -14,7 +14,7 @@ from genomedata._close_data import close_data
 from genomedata.load_genomedata import load_genomedata
 from genomedata import Genome
 
-import test_genomedata
+from . import test_genomedata
 from six.moves import range
 
 """

--- a/test/test_genomedata.py
+++ b/test/test_genomedata.py
@@ -535,30 +535,3 @@ class GenomedataNoDataTester(unittest.TestCase):
             self.assertArraysEqual(genome["chr1"][305:310, new_track_name],
                                    [-2.65300012, 0.37200001, 0.37200001,
                                     0.37200001, 0.37099999])
-
-
-def test_genomedata(*args):
-    pass
-
-
-def parse_options(args):
-
-    from argparse import ArgumentParser
-    from . import __version__
-
-    parser = ArgumentParser(prog='test_genomedata',
-                            version=__version__)
-
-    args = parser.parse_args(args)
-
-    return args
-
-
-def main(args=sys.argv[1:]):
-    args = parse_options(args)
-
-    return test_genomedata(*args)
-
-
-if __name__ == "__main__":
-    sys.exit(main())

--- a/test/test_genomedata.py
+++ b/test/test_genomedata.py
@@ -11,7 +11,6 @@ __version__ = "$Revision$"
 
 # Copyright 2010-2013 Michael M. Hoffman <mmh1@uw.edu>
 import os
-import sys
 from tempfile import mkdtemp, mkstemp
 import unittest
 import warnings


### PR DESCRIPTION
This PR adds mypy type checking for future versions of Genomedata.

It detected an invalid relative import in a non-package (the test directory). The code in question was performing argument parsing in a script never meant to be called directly. Even if it were successful at parsing the args, it would call a function that only used `pass`.