### PR TITLE
Fix summary statistics for bigWig files to produce 1-dimensional arrays

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+1.7.1:
+* fix array dimensionality consistency for summary statistics on bigWig files
+
 1.7.0:
 * adapted existing python interface to open bigWig files
 

--- a/genomedata/_bigwig.py
+++ b/genomedata/_bigwig.py
@@ -69,23 +69,23 @@ class _BigWigChromosomeList(_ChromosomeList):
     # NB: One implicit trackname across chromosomes for stat retrieval
     @property
     def mins(self):
-        return array(self.bw_file_header['minVal'])
+        return array([self.bw_file_header['minVal']])
 
     @property
     def maxs(self):
-        return array(self.bw_file_header['maxVal'])
+        return array([self.bw_file_header['maxVal']])
 
     @property
     def sums(self):
-        return array(self.bw_file_header['sumData'])
+        return array([self.bw_file_header['sumData']])
 
     @property
     def sums_squares(self):
-        return array(self.bw_file_header['sumSquared'])
+        return array([self.bw_file_header['sumSquared']])
 
     @property
     def num_datapoints(self):
-        return array(self.bw_file_header['nBasesCovered'])
+        return array([self.bw_file_header['nBasesCovered']])
 
     def tracknames_continuous(self):
         # Return filepath to bigWig as implicit trackname

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -304,7 +304,7 @@ class GenomedataBigWigTester(unittest.TestCase):
             self.assertEqual(genome.maxs, [93473])
             self.assertEqual(genome.sums, [32720078])
             self.assertEqual(genome.sums_squares, [1280737190372])
-            self.assertAlmostEqual(genome.vars, 414615.8372, places=4)
+            self.assertAlmostEqual(genome.vars[0], 414615.8372, places=4)
 
             # Test chromosome retrieval
             chr1 = genome["chr1"]  # memoization


### PR DESCRIPTION
Fixes bigWig files summary statistic methods (sums, maxs, etc.) producing 0-dimensional arrays (`array(val)`) to 1-dimensional arrays (`array([val])`) to keep consistency with an implicit single track.