### PR TITLE
Fix debug representation of chromosomes for bigWig files

### DIFF
--- a/genomedata/_bigwig.py
+++ b/genomedata/_bigwig.py
@@ -110,6 +110,9 @@ class _BigWigChromosome(Chromosome):
         self.bw_file = bw_file
         self.filepath = filepath
 
+        # For string representation in Chromosome
+        self.filename = str(self.filepath)
+
         # Check if the chromosome exists
         if name not in self.bw_file.chroms():
             raise ValueError

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -275,7 +275,9 @@ class GenomedataBigWigTester(unittest.TestCase):
 
     def test_interface(self):
         with Genome(self.bigwig_name) as genome:
-            # TODO: Genome interface testing
+
+            self.assertEqual(repr(genome),
+                             "Genome('{}')".format(self.bigwig_name))
 
             # Test sorted order of chromosomes
             chr_names = [chromosome.name for chromosome in genome]
@@ -308,6 +310,11 @@ class GenomedataBigWigTester(unittest.TestCase):
 
             # Test chromosome retrieval
             chr1 = genome["chr1"]  # memoization
+
+            self.assertEqual(repr(chr1),
+                             "<Chromosome 'chr1', file='{}'>".format(
+                             self.bigwig_name))
+            self.assertEqual(str(chr1), "chr1")
 
             # Chromosome interface testing
             # chr1	569800	569801	0.01108


### PR DESCRIPTION
Fixes `repr()` methods on Chromsomes when using bigWig files. Adds regression tests for the corresponding interface for both `Genome` and `Chromsome` objects