### PR TITLE
Fix consistency in array shape output when track indexing on bigWig files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 1.7.2:
 * required Python is now >=3.9
+* fixed consistency in array shape output when track indexing on bigWig files
 
 1.7.1:
 * fix array dimensionality consistency for summary statistics on bigWig files

--- a/doc/genomedata.rst
+++ b/doc/genomedata.rst
@@ -374,8 +374,7 @@ format and the bigWig file format:
 
 - There is only one track per bigWig file and it is implicitly set to the
   filename of the bigWig.
-- Any track indicies or (file)name specfied are only considered for shaping
-  array output
+- Track indexing is only used to shape dimensionality of output.
 - Summary statistics are taken from the bigWig file formation definition
   which are stored as integers. There may be some differences precision.
 - Each :class:`Chromosome <Chromosome>` is represented with 1 underlying

--- a/doc/genomedata.rst
+++ b/doc/genomedata.rst
@@ -374,6 +374,8 @@ format and the bigWig file format:
 
 - There is only one track per bigWig file and it is implicitly set to the
   filename of the bigWig.
+- Any track indicies or (file)name specfied are only considered for shaping
+  array output
 - Summary statistics are taken from the bigWig file formation definition
   which are stored as integers. There may be some differences precision.
 - Each :class:`Chromosome <Chromosome>` is represented with 1 underlying

--- a/genomedata/_bigwig.py
+++ b/genomedata/_bigwig.py
@@ -1,6 +1,6 @@
 import struct
 
-from numpy import array, ndarray, reshape
+from numpy import array, ndarray
 import pyBigWig
 
 from ._chromosome import (Chromosome, CONTINUOUS_DTYPE, _ChromosomeList,

--- a/genomedata/_bigwig.py
+++ b/genomedata/_bigwig.py
@@ -170,11 +170,12 @@ class _BigWigChromosome(Chromosome):
            track_key != slice(None)):
             # Return a scalar value (no array)
             data = data[0]
-        # If indexing based on track in an list-type
+        # If indexing based on track is a list-type
         elif isinstance(track_key, (list, ndarray)):
             # Shape the data depending on track indexing
             # (compatability with PyTables/HDF5)
             data = data.reshape((range_length, 1))
+
             # NB: When track_key is a list that contains non-integers,
             # there is no behaviour defined and is not numpy-like (will error)
             # This is equivalent to the PyTables/HDF5 implementation


### PR DESCRIPTION
This fixes an inconsistency in array shape output depending on how the "track" portion of bigWig files are indexed. The tests have been updated to be consistent with the expected shape output.

There is notable undefined behaviour discovered when matching implementations. Specifically in the case when track indexing with tracknames in an array-like.

The following is allowed:
```python
chr1[0, [0]] = [[data]]
```
The following is *not* and currently is not defined by the implementation anywhere and is an error:
```python
chr1[0, ["trackname"]]
```

Notably the track indexing can be a list of lists as deep as you want to shape your output.
e.g.
```python
chr[0, [[0]]] = [[[data]]]
```
