### PR TITLE
Replace deprecated path API usage

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+1.7.3:
+* replaced deprecated path API uses
+
 1.7.2:
 * required Python is now >=3.9
 * fixed consistency in array shape output when track indexing on bigWig files
@@ -129,7 +132,7 @@
 
 1.2.3:
 
-* DO NOT USE: genomedata-load-seq doesn't work 
+* DO NOT USE: genomedata-load-seq doesn't work
 * allow use with PyTables >=2.2
 * new command: genomedata-info: "genomedata-info tracknames ARCHIVE"
   prints the tracknames for ARCHIVE
@@ -188,7 +191,7 @@
   the handling of non-context-manager Genome objects by requiring a call
   to Genome.close() when finished.
 * Added an option to genomedata-load-seq and genomedata-load
-  to specify the Genomedata archive implementation (directory/file). 
+  to specify the Genomedata archive implementation (directory/file).
   Default is directory if number of sequences is at least 100.
 * Added support for replacing data in Genomedata tracks.
 * General documentation improvements
@@ -210,7 +213,7 @@
 * extend documentation, including examples
 * extended API with: chromosome[start:end], chromosome.seq[start:end],
   and chromosome.supercontigs[start:end]
-* added reasonable repr and str return values for Genome, Chromosome, 
+* added reasonable repr and str return values for Genome, Chromosome,
   and Supercontig
 
 0.1.5:

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 1.7.3:
-* replaced deprecated path API uses
+* replace deprecated .isdir and .isfile path API uses with is_dir and is_file
+  from version 16.12
+* add numpy 2.0 compatibilty
 
 1.7.2:
 * required Python is now >=3.9

--- a/genomedata/__init__.py
+++ b/genomedata/__init__.py
@@ -101,7 +101,7 @@ class Genome(object):
             raise IOError("Could not find Genomedata archive: %s" % filepath)
 
         # If it's a file we are opening
-        if filepath.isfile():
+        if filepath.is_file():
             # Check if the file type is bigWig
             # NB: Could consider checking by filename extension only
             if is_big_wig(filepath):
@@ -110,7 +110,7 @@ class Genome(object):
             else:
                 self._chromosomes = _HDF5SingleFileChromosomeList(
                     filepath, *args, **kwargs)
-        elif filepath.isdir():
+        elif filepath.is_dir():
             # Genomedata directory
             self._chromosomes = _HDF5DirectoryChromosomeList(filepath, *args,
                                                              **kwargs)

--- a/genomedata/_load_seq.py
+++ b/genomedata/_load_seq.py
@@ -358,7 +358,7 @@ def load_seq(gdfilename, filenames, verbose=False, mode=None,
             print(msg, file=sys.stderr)
     if mode == "dir":
         if gdpath.exists():
-            assert gdpath.isdir()
+            assert gdpath.is_dir()
         else:
             gdpath.makedirs()
     elif mode == "file":

--- a/genomedata/load_genomedata.py
+++ b/genomedata/load_genomedata.py
@@ -95,7 +95,7 @@ def load_genomedata(gdfilename, tracks=None, seqfilenames=None, mode=None,
             else:
                 seqfile_desc = "assembly"
 
-            if not Path(seqfilename).isfile():
+            if not Path(seqfilename).is_file():
                 die("Could not find %s file: %s" % (seqfile_desc, seqfilename))
 
         if verbose:
@@ -112,7 +112,7 @@ def load_genomedata(gdfilename, tracks=None, seqfilenames=None, mode=None,
             try:
                 track_names = []
                 for track_name, track_filename in tracks:
-                    if Path(track_filename).isfile():
+                    if Path(track_filename).is_file():
                         if track_name not in track_names:  # No duplicates
                             track_names.append(track_name)
                     else:
@@ -152,7 +152,7 @@ def load_genomedata(gdfilename, tracks=None, seqfilenames=None, mode=None,
         # Move/repack h5 files to output directory
         if isdir:  # Repack each h5 file separately
             if gdpath.exists():
-                assert gdpath.isdir()
+                assert gdpath.is_dir()
             else:
                 gdpath.makedirs()
 
@@ -173,7 +173,7 @@ def load_genomedata(gdfilename, tracks=None, seqfilenames=None, mode=None,
                 print(">> Cleaning up...", end=' ', file=sys.stderr)
 
             sys.stdout.flush()
-            if tempdatapath.isfile():
+            if tempdatapath.is_file():
                 tempdatapath.remove()
             else:
                 tempdatapath.rmtree()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "tables>=3.0,!=3.4.1",
   "six",
   "textinput>=0.2.0",
-  "path.py>=16.12",
+  "path>=16.12",
   "pybigwig",
 ]
 description = "tools for accessing large amounts of genomic data"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "tables>=3.0,!=3.4.1",
   "six",
   "textinput>=0.2.0",
-  "path.py>=11",
+  "path.py>=16.12",
   "pybigwig",
 ]
 description = "tools for accessing large amounts of genomic data"

--- a/test/test_genomedata.py
+++ b/test/test_genomedata.py
@@ -297,10 +297,10 @@ class GenomedataTester(GenomedataTesterBase):
             for chrom in self.chroms:
                 filename = os.extsep.join([chrom, "genomedata"])
                 filepath = self.gdfilepath.joinpath(filename)
-                self.assertTrue(filepath.isfile(),
+                self.assertTrue(filepath.is_file(),
                                 "Chromosome file was not found: %s" % filepath)
         elif self.mode == "file":
-            self.assertTrue(self.gdfilepath.isfile(),
+            self.assertTrue(self.gdfilepath.is_file(),
                             "Genomedata archive was not created: %r" %
                             self.gdfilepath)
         else:
@@ -481,10 +481,10 @@ class GenomedataNoDataTester(unittest.TestCase):
             for chrom in self.chroms:
                 filename = os.extsep.join([chrom, "genomedata"])
                 filepath = self.gdfilepath.joinpath(filename)
-                self.assertTrue(filepath.isfile(),
+                self.assertTrue(filepath.is_file(),
                                 "Chromosome file was not found: %s" % filepath)
         elif self.mode == "file":
-            self.assertTrue(self.gdfilepath.isfile(),
+            self.assertTrue(self.gdfilepath.is_file(),
                             "Genomedata archive was not created: %r" %
                             self.gdfilepath)
         else:


### PR DESCRIPTION
Newer versions of the `path` library [deprecated and removed some method calls](https://path.readthedocs.io/en/latest/history.html#v16-12-0) that were used in Genomedata. This replaces the calls with their equivalent.

Fixes Issue #70 